### PR TITLE
Update to newer Sky130 version

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -20,6 +20,6 @@ jobs:
         source install.sh
     - name: Run regression test
       run: |
-        export PDKPATH=`realpath PDKS/sky130`
+        export PDKPATH=`realpath PDKS/sky130A`
         export SKYWATER=`realpath skywater-pdk`
         source regress.sh

--- a/README.md
+++ b/README.md
@@ -58,9 +58,14 @@ make install
 cd ..
 ```
 
-In addition, the ``PDKPATH`` environment variable should be set to the absoute path of ``PDKS/sky130``, e.g.
+In addition, the ``PDKPATH`` environment variable should be set to the absoute path of ``PDKS/sky130A``, e.g.
 ```
-export PDKPATH=`realpath PDKS/sky130`
+export PDKPATH=`realpath PDKS/sky130A`
+```
+
+For simulations in ngspice, the regression uses the ``SKYWATER`` environment variable, set to the absolute path of the skywater repository ``skywater-pdk``, e.g.
+```
+export SKYWATER=`realpath skywater-pdk`
 ```
 
 ## Running magic scripts

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ quit
 LVS can be run to compare the design netlist with the extracted netlist using ``netgen``:
 
 ```shell
-netgen -batch lvs "design_netlist design_top_cell" "ext_netlist ext_top_cell" $PDKPATH/libs.tech/netgen/sky130_setup.tcl
+netgen -batch lvs "design_netlist design_top_cell" "ext_netlist ext_top_cell" $PDKPATH/libs.tech/netgen/sky130A_setup.tcl
 ```
 
 ## Running SPICE simulations

--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,7 @@ cd ..
 # install open_pdks
 git clone https://github.com/RTimothyEdwards/open_pdks.git
 cd open_pdks
-./configure --with-sky130-source=`realpath ../skywater-pdk` --with-sky130-local-path=`realpath ../PDKS`
+./configure --enable-sky130-pdk=`realpath ../skywater-pdk` --with-sky130-local-path=`realpath ../PDKS`
 make
 make install
 cd ..

--- a/inv1.spice
+++ b/inv1.spice
@@ -16,6 +16,6 @@
 
 
 .subckt sky130_fd_sc_hd__inv_1 A VGND VNB VPB VPWR Y
-X0 Y A VGND VNB sky130_fd_pr__nfet_01v8 w=650000u l=150000u
-X1 Y A VPWR VPB sky130_fd_pr__pfet_01v8_hvt w=1e+06u l=150000u
+X0 VGND A Y VNB sky130_fd_pr__nfet_01v8 w=650000u l=150000u
+X1 VPWR A Y VPB sky130_fd_pr__pfet_01v8_hvt w=1e+06u l=150000u
 .ends

--- a/inv1.spice
+++ b/inv1.spice
@@ -16,6 +16,6 @@
 
 
 .subckt sky130_fd_sc_hd__inv_1 A VGND VNB VPB VPWR Y
-X0 VGND A Y VNB sky130_fd_pr__nfet_01v8 w=650000u l=150000u
-X1 VPWR A Y VPB sky130_fd_pr__pfet_01v8_hvt w=1e+06u l=150000u
+X0 Y A VGND VNB sky130_fd_pr__nfet_01v8 w=650000u l=150000u
+X1 Y A VPWR VPB sky130_fd_pr__pfet_01v8_hvt w=1e+06u l=150000u
 .ends

--- a/regress.sh
+++ b/regress.sh
@@ -30,7 +30,7 @@ export GDS_FILE=inv1.gds
 export LVS_FILE=lvs.spice
 export PEX_FILE=pex.spice
 magic -noconsole -dnull run_ext.tcl
-netgen -batch lvs "$LVS_FILE $CELL_NAME" "inv1.spice $CELL_NAME" $PDKPATH/libs.tech/netgen/sky130_setup.tcl | tee lvs.log
+netgen -batch lvs "$LVS_FILE $CELL_NAME" "inv1.spice $CELL_NAME" $PDKPATH/libs.tech/netgen/sky130A_setup.tcl | tee lvs.log
 if grep -q "Netlists do not match" lvs.log ; then
     echo "Found LVS errors, which was not expected :-("
     exit 1
@@ -44,7 +44,7 @@ export GDS_FILE=inv1_bad.gds
 export LVS_FILE=lvs_bad.spice
 export PEX_FILE=pex_bad.spice
 magic -noconsole -dnull run_ext.tcl
-netgen -batch lvs "$LVS_FILE $CELL_NAME" "inv1.spice $CELL_NAME" $PDKPATH/libs.tech/netgen/sky130_setup.tcl | tee lvs.log
+netgen -batch lvs "$LVS_FILE $CELL_NAME" "inv1.spice $CELL_NAME" $PDKPATH/libs.tech/netgen/sky130A_setup.tcl | tee lvs.log
 if grep -q "Netlists do not match" lvs.log ; then
     echo "Found LVS errors, as expected :-)"
 else

--- a/regress.sh
+++ b/regress.sh
@@ -1,6 +1,5 @@
 # copy over RC file
-find
-cp $PDKPATH/libs.tech/magic/sky130.magicrc .magicrc
+cp $PDKPATH/libs.tech/magic/sky130A.magicrc .magicrc
 
 # general setup
 export CELL_NAME=sky130_fd_sc_hd__inv_1


### PR DESCRIPTION
Most of the changes are just slight differences in naming. 
There is one additional change to inv1.spice that actually changes the netlist used in LVS. It seems that the extracted netlist uses the port ordering "Drain Gate Source Bulk". The old inv1.spice used a different ordering, "Source Gate Drain Bulk", so the LVS was failing. It seems that "Drain Gate Source Bulk" is the standard, so I updated inv1.spice to match the extracted version. I'm a little apprehensive about updating the hand-written netlist to match the extraction rather than the other way around, especially when the hand-written one used to match with the old extraction.